### PR TITLE
feat: R0 DBOS acquisition spike (T01/T03)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,7 @@
-# Copy to .env. Never commit .env.
+# Local env template. Copy values from /etc/rkp/rkp-postgres.env on the VPS.
+# Never commit a filled copy.
 
-# PostgreSQL 18
-DATABASE_URL=postgresql://rkp:change-me@127.0.0.1:5432/rkp
-DBOS_DATABASE_URL=postgresql://rkp:change-me@127.0.0.1:5432/rkp
-
-# Directus 12 — licence key is a secret (NFR-02)
-DIRECTUS_URL=http://127.0.0.1:8055
-DIRECTUS_KEY=
-DIRECTUS_SECRET=
-DIRECTUS_LICENSE_KEY=
-
-# AI gateway — public regulatory material only (FR-54)
-OPENAI_API_KEY=
-OPENAI_REGION=us
-MODEL_STRUCTURED=
-MODEL_VISION=
-
-# Evidence
+RKP_TEST_DATABASE_URL=postgresql://rkp:change-me@127.0.0.1:5433/rkp
+DATABASE_URL=postgresql://rkp:change-me@127.0.0.1:5433/rkp
+DBOS_DATABASE_URL=postgresql://rkp:change-me@127.0.0.1:5433/rkp
 EVIDENCE_ROOT=/var/lib/rkp/evidence
-OFFSITE_S3_ENDPOINT=
-OFFSITE_S3_BUCKET=
-OFFSITE_S3_ACCESS_KEY=
-OFFSITE_S3_SECRET_KEY=

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
-        with:
-          python-version: "3.11"
+      - name: Python
+        run: uv python install 3.11
       - name: Install
-        run: uv pip install --system -e ".[dev]"
+        run: uv pip install --python 3.11 -e ".[dev]"
       - name: Test
         env:
           RKP_TEST_DATABASE_URL: postgresql://rkp:test@127.0.0.1:5432/rkp
-        run: pytest -q
+        run: uv run --python 3.11 pytest -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v4
-      - name: Python
-        run: uv python install 3.11
-      - name: Install
-        run: uv pip install --python 3.11 -e ".[dev]"
       - name: Test
         env:
           RKP_TEST_DATABASE_URL: postgresql://rkp:test@127.0.0.1:5432/rkp
-        run: uv run --python 3.11 pytest -q
+        run: |
+          uv python install 3.11
+          uv venv --python 3.11
+          uv pip install -e ".[dev]"
+          uv run pytest -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg18
+        env:
+          POSTGRES_USER: rkp
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: rkp
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U rkp -d rkp"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v4
+        with:
+          python-version: "3.11"
+      - name: Install
+        run: uv pip install --system -e ".[dev]"
+      - name: Test
+        env:
+          RKP_TEST_DATABASE_URL: postgresql://rkp:test@127.0.0.1:5432/rkp
+        run: pytest -q

--- a/.gitignore
+++ b/.gitignore
@@ -1,39 +1,9 @@
-# Secrets and local env
+*.egg-info
+.venv
+__pycache__
+.pytest_cache
+*.pyc
 .env
 .env.*
 !.env.example
-*.pem
-*.key
-directus-license*
-licence-key*
-
-# Python
-.venv/
-venv/
-__pycache__/
-*.pyc
-.pytest_cache/
-.mypy_cache/
-.ruff_cache/
-
-# Node (Directus / website)
-node_modules/
-.next/
-dist/
-
-# Evidence store (content-addressed originals — too large, not for git)
 data/evidence/
-data/page-images/
-*.pdf
-
-# DBOS / Postgres local
-*.sql.gz
-pgdata/
-
-# OS / editor
-.DS_Store
-.idea/
-.vscode/
-
-# Hermes planning working copies may be local; committed snapshots live under docs/
-scratch-local/

--- a/README.md
+++ b/README.md
@@ -39,4 +39,6 @@ Operating model (one VPS): [`docs/operating-model-v2.2-one-vps.md`](docs/operati
 
 ## Status
 
-Stage 0 locked. Execution overlay E0 written. Next: E1 `wk-main` split (approval) then T01 Postgres as approved IaC. Do not start R1 schema work that depends on DBOS until the spike gate passes.
+Stage 0 locked. R0 spike in progress on a PR: Postgres 18.6 + pgvector 0.8.6 on `127.0.0.1:5433`, DBOS acquisition workflow with crash-replay tests.
+
+Do not start R1 schema work that depends on DBOS until that PR is merged and the spike gate is accepted.

--- a/deploy/HOST.md
+++ b/deploy/HOST.md
@@ -1,0 +1,9 @@
+# R0 host notes (not secrets)
+
+- Worker user: `wk-main` uid 1999, no docker group, password locked, nologin.
+- systemd slice `wk-main.slice`: MemoryMax=4G.
+- Product Postgres: Docker `rkp-postgres` image `pgvector/pgvector:pg18`, host `127.0.0.1:5433` only.
+- Paperclip embedded Postgres remains `127.0.0.1:54329` — do not use it.
+- Credentials: `/etc/rkp/rkp-postgres.env` mode 640 root:docker. Not in git.
+- Evidence root: `/var/lib/rkp/evidence` owned by `wk-main`.
+- Verified 2026-09-05: PostgreSQL 18.6, pgvector 0.8.6.

--- a/deploy/compose.postgres.yaml
+++ b/deploy/compose.postgres.yaml
@@ -1,0 +1,15 @@
+# RKP worker — Compose is documentation; live instance is `rkp-postgres` on 127.0.0.1:5433.
+# Do not bind 54329 (Paperclip embedded Postgres).
+services:
+  postgres:
+    image: pgvector/pgvector:pg18
+    container_name: rkp-postgres
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:5433:5432"
+    env_file:
+      - /etc/rkp/rkp-postgres.env
+    volumes:
+      - /var/lib/rkp/pg:/var/lib/postgresql
+    mem_limit: 4g
+    cpus: 2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "rkp"
+version = "0.1.0"
+description = "Regulatory knowledge platform — R0 acquisition spike"
+requires-python = ">=3.11"
+dependencies = [
+  "dbos==2.31.0",
+  "psycopg[binary]==3.3.5",
+]
+
+[project.optional-dependencies]
+dev = ["pytest==9.1.1"]
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["rkp*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/rkp/__init__.py
+++ b/rkp/__init__.py
@@ -1,0 +1,5 @@
+from rkp.acquisition.catalog import Catalog, SourceVersion
+from rkp.acquisition.store import EvidenceStore
+from rkp.acquisition.workflow import AcquireResult, acquire
+
+__all__ = ["Catalog", "SourceVersion", "EvidenceStore", "AcquireResult", "acquire"]

--- a/rkp/acquisition/__init__.py
+++ b/rkp/acquisition/__init__.py
@@ -1,0 +1,5 @@
+from rkp.acquisition.catalog import Catalog, SourceVersion
+from rkp.acquisition.store import EvidenceStore
+from rkp.acquisition.workflow import AcquireResult, acquire
+
+__all__ = ["Catalog", "SourceVersion", "EvidenceStore", "AcquireResult", "acquire"]

--- a/rkp/acquisition/catalog.py
+++ b/rkp/acquisition/catalog.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import psycopg
+
+
+SCHEMA_SQL = """
+CREATE SCHEMA IF NOT EXISTS rkp;
+
+CREATE TABLE IF NOT EXISTS rkp.sources (
+    id              bigserial PRIMARY KEY,
+    url             text NOT NULL UNIQUE
+);
+
+CREATE TABLE IF NOT EXISTS rkp.source_versions (
+    id              bigserial PRIMARY KEY,
+    source_id       bigint NOT NULL REFERENCES rkp.sources(id),
+    sha256          char(64) NOT NULL,
+    headers         jsonb NOT NULL DEFAULT '{}'::jsonb,
+    official_status text NOT NULL DEFAULT 'unverified',
+    legal_status    text NOT NULL DEFAULT 'unverified',
+    created_at      timestamptz NOT NULL DEFAULT now(),
+    UNIQUE (source_id, sha256)
+);
+
+CREATE INDEX IF NOT EXISTS source_versions_sha256 ON rkp.source_versions (sha256);
+"""
+
+
+@dataclass(frozen=True)
+class SourceVersion:
+    source_id: int
+    source_version_id: int
+    sha256: str
+    url: str
+
+
+class Catalog:
+    def __init__(self, dsn: str) -> None:
+        self.dsn = dsn
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        with psycopg.connect(self.dsn) as conn:
+            conn.execute(SCHEMA_SQL)
+            conn.commit()
+
+    def reset_for_tests(self) -> None:
+        with psycopg.connect(self.dsn) as conn:
+            conn.execute("DROP SCHEMA IF EXISTS rkp CASCADE")
+            conn.execute("DROP SCHEMA IF EXISTS dbos CASCADE")
+            conn.commit()
+        self._ensure_schema()
+
+    def record_source_version(
+        self, *, url: str, sha256: str, headers: dict | None = None
+    ) -> SourceVersion:
+        headers = headers or {}
+        with psycopg.connect(self.dsn) as conn:
+            source_id = conn.execute(
+                """
+                INSERT INTO rkp.sources (url) VALUES (%s)
+                ON CONFLICT (url) DO UPDATE SET url = EXCLUDED.url
+                RETURNING id
+                """,
+                (url,),
+            ).fetchone()[0]
+            row = conn.execute(
+                """
+                INSERT INTO rkp.source_versions (source_id, sha256, headers)
+                VALUES (%s, %s, %s::jsonb)
+                ON CONFLICT (source_id, sha256) DO UPDATE
+                  SET source_id = rkp.source_versions.source_id
+                RETURNING id, sha256
+                """,
+                (source_id, sha256, psycopg.types.json.Json(headers)),
+            ).fetchone()
+            conn.commit()
+        return SourceVersion(
+            source_id=source_id,
+            source_version_id=row[0],
+            sha256=row[1],
+            url=url,
+        )
+
+    def count_sources(self) -> int:
+        with psycopg.connect(self.dsn) as conn:
+            return conn.execute("SELECT count(*) FROM rkp.sources").fetchone()[0]
+
+    def count_source_versions(self) -> int:
+        with psycopg.connect(self.dsn) as conn:
+            return conn.execute("SELECT count(*) FROM rkp.source_versions").fetchone()[0]

--- a/rkp/acquisition/store.py
+++ b/rkp/acquisition/store.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+
+class EvidenceStore:
+    """Content-addressed store. Path layout: {root}/{sha256[:2]}/{sha256}."""
+
+    def __init__(self, root: str | Path) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def put(self, data: bytes) -> str:
+        digest = hashlib.sha256(data).hexdigest()
+        path = self._path(digest)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        if not path.exists():
+            tmp = path.with_suffix(".tmp")
+            tmp.write_bytes(data)
+            tmp.replace(path)
+        return digest
+
+    def get(self, digest: str) -> bytes:
+        return self._path(digest).read_bytes()
+
+    def _path(self, digest: str) -> Path:
+        if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+            raise ValueError("digest must be sha256 hex")
+        return self.root / digest[:2] / digest

--- a/rkp/acquisition/watcher.py
+++ b/rkp/acquisition/watcher.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class Fetcher(Protocol):
+    def get(self, url: str) -> bytes: ...
+
+
+@dataclass(frozen=True)
+class WatchResult:
+    url: str
+    outcome: str  # "changed" | "no_change" | "failure"
+    sha256: str | None
+    alert: bool
+
+
+def check_listing(
+    *,
+    url: str,
+    fetcher: Fetcher,
+    previous_sha256: str | None,
+) -> WatchResult:
+    """FR-44: failure is not recorded as no_change."""
+    import hashlib
+
+    try:
+        body = fetcher.get(url)
+    except Exception:
+        return WatchResult(url=url, outcome="failure", sha256=None, alert=True)
+    digest = hashlib.sha256(body).hexdigest()
+    if previous_sha256 is not None and digest == previous_sha256:
+        return WatchResult(url=url, outcome="no_change", sha256=digest, alert=False)
+    return WatchResult(url=url, outcome="changed", sha256=digest, alert=False)

--- a/rkp/acquisition/workflow.py
+++ b/rkp/acquisition/workflow.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dbos import DBOS, DBOSConfig, SetWorkflowID
+
+from rkp.acquisition.catalog import Catalog, SourceVersion
+from rkp.acquisition.store import EvidenceStore
+
+
+@dataclass(frozen=True)
+class AcquireResult:
+    source_id: int
+    source_version_id: int
+    sha256: str
+    url: str
+
+
+def acquire(
+    *,
+    url: str,
+    body: bytes,
+    store: EvidenceStore,
+    catalog: Catalog,
+    headers: dict | None = None,
+) -> AcquireResult:
+    """Idempotent intake: CAS then catalog. Safe to replay after crash."""
+    digest = store.put(body)
+    recorded: SourceVersion = catalog.record_source_version(
+        url=url, sha256=digest, headers=headers
+    )
+    return AcquireResult(
+        source_id=recorded.source_id,
+        source_version_id=recorded.source_version_id,
+        sha256=recorded.sha256,
+        url=recorded.url,
+    )
+
+
+def dbos_config(system_database_url: str) -> DBOSConfig:
+    return DBOSConfig(
+        name="rkp-acquisition",
+        system_database_url=system_database_url,
+        dbos_system_schema="dbos",
+        run_admin_server=False,
+        log_level="WARNING",
+    )
+
+
+@DBOS.step()
+def store_bytes_step(root: str, body: bytes) -> str:
+    return EvidenceStore(root).put(body)
+
+
+@DBOS.step()
+def catalog_version_step(
+    dsn: str, url: str, sha256: str, headers: dict | None
+) -> dict:
+    rec = Catalog(dsn).record_source_version(url=url, sha256=sha256, headers=headers)
+    return {
+        "source_id": rec.source_id,
+        "source_version_id": rec.source_version_id,
+        "sha256": rec.sha256,
+        "url": rec.url,
+    }
+
+
+@DBOS.workflow()
+def acquire_workflow(
+    dsn: str,
+    root: str,
+    url: str,
+    body: bytes,
+    headers: dict | None = None,
+) -> dict:
+    digest = store_bytes_step(root, body)
+    return catalog_version_step(dsn, url, digest, headers)
+
+
+def run_acquire_workflow(
+    *,
+    system_database_url: str,
+    workflow_id: str,
+    url: str,
+    body: bytes,
+    store: EvidenceStore,
+    catalog: Catalog,
+    headers: dict | None = None,
+) -> AcquireResult:
+    DBOS.destroy(workflow_completion_timeout_sec=0)
+    DBOS(config=dbos_config(system_database_url))
+    DBOS.launch()
+    try:
+        with SetWorkflowID(workflow_id):
+            handle = DBOS.start_workflow(
+                acquire_workflow,
+                catalog.dsn,
+                str(store.root),
+                url,
+                body,
+                headers,
+            )
+            data = handle.get_result()
+    finally:
+        DBOS.destroy(workflow_completion_timeout_sec=5)
+    return AcquireResult(
+        source_id=data["source_id"],
+        source_version_id=data["source_version_id"],
+        sha256=data["sha256"],
+        url=data["url"],
+    )

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,10 @@
+# Tests
+
+Run against the product Postgres on this VPS (`127.0.0.1:5433`), not Paperclip `:54329`.
+
+```bash
+export RKP_TEST_DATABASE_URL="postgresql://rkp:…@127.0.0.1:5433/rkp"
+PYTHONPATH=. pytest -q
+```
+
+Store tests run without a database. Catalog, acquire, and DBOS replay tests skip unless `RKP_TEST_DATABASE_URL` is set.

--- a/tests/test_acquisition.py
+++ b/tests/test_acquisition.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+import pytest
+
+from rkp.acquisition.catalog import Catalog
+from rkp.acquisition.store import EvidenceStore
+from rkp.acquisition.workflow import acquire, run_acquire_workflow
+
+
+FIXTURE_A = b"%PDF-1.4 fixture-a\n"
+FIXTURE_B = b"%PDF-1.4 fixture-b-changed\n"
+URL = "https://rbi.org.in/fixtures/md-nbfc.pdf"
+
+
+@pytest.fixture
+def evidence_root(tmp_path: Path) -> Path:
+    root = tmp_path / "evidence"
+    root.mkdir()
+    return root
+
+
+@pytest.fixture
+def store(evidence_root: Path) -> EvidenceStore:
+    return EvidenceStore(evidence_root)
+
+
+def test_store_puts_bytes_at_sha256_path(store: EvidenceStore, evidence_root: Path) -> None:
+    digest = store.put(FIXTURE_A)
+    expected = hashlib.sha256(FIXTURE_A).hexdigest()
+    assert digest == expected
+    assert store.get(digest) == FIXTURE_A
+    stored = evidence_root / digest[:2] / digest
+    assert stored.read_bytes() == FIXTURE_A
+
+
+def test_store_put_is_idempotent(store: EvidenceStore) -> None:
+    a = store.put(FIXTURE_A)
+    b = store.put(FIXTURE_A)
+    assert a == b
+    assert store.get(a) == FIXTURE_A
+
+
+@pytest.fixture
+def catalog() -> Catalog:
+    url = os.environ.get("RKP_TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("RKP_TEST_DATABASE_URL not set")
+    c = Catalog(url)
+    c.reset_for_tests()
+    return c
+
+
+def test_identical_bytes_do_not_create_new_source_version(catalog: Catalog, store: EvidenceStore) -> None:
+    digest = store.put(FIXTURE_A)
+    first = catalog.record_source_version(url=URL, sha256=digest, headers={"etag": "1"})
+    second = catalog.record_source_version(url=URL, sha256=digest, headers={"etag": "1"})
+    assert first.source_version_id == second.source_version_id
+    assert catalog.count_source_versions() == 1
+    assert catalog.count_sources() == 1
+
+
+def test_changed_bytes_at_same_url_create_new_version_same_source(
+    catalog: Catalog, store: EvidenceStore
+) -> None:
+    d1 = store.put(FIXTURE_A)
+    d2 = store.put(FIXTURE_B)
+    v1 = catalog.record_source_version(url=URL, sha256=d1, headers={})
+    v2 = catalog.record_source_version(url=URL, sha256=d2, headers={})
+    assert v1.source_id == v2.source_id
+    assert v1.source_version_id != v2.source_version_id
+    assert catalog.count_sources() == 1
+    assert catalog.count_source_versions() == 2
+
+
+def test_acquire_twice_is_idempotent(catalog: Catalog, store: EvidenceStore) -> None:
+    r1 = acquire(url=URL, body=FIXTURE_A, store=store, catalog=catalog)
+    r2 = acquire(url=URL, body=FIXTURE_A, store=store, catalog=catalog)
+    assert r1.source_version_id == r2.source_version_id
+    assert catalog.count_source_versions() == 1
+
+
+def test_crash_between_store_and_catalog_does_not_duplicate(
+    catalog: Catalog, store: EvidenceStore
+) -> None:
+    digest = store.put(FIXTURE_A)
+    assert store.get(digest) == FIXTURE_A
+    assert catalog.count_source_versions() == 0
+    result = acquire(url=URL, body=FIXTURE_A, store=store, catalog=catalog)
+    assert result.sha256 == digest
+    assert catalog.count_source_versions() == 1
+    replay = acquire(url=URL, body=FIXTURE_A, store=store, catalog=catalog)
+    assert replay.source_version_id == result.source_version_id
+    assert catalog.count_source_versions() == 1
+
+
+def test_dbos_same_workflow_id_replays_without_new_version(
+    catalog: Catalog, store: EvidenceStore
+) -> None:
+    dsn = os.environ["RKP_TEST_DATABASE_URL"]
+    workflow_id = "acquire-dc8-replay"
+    first = run_acquire_workflow(
+        system_database_url=dsn,
+        workflow_id=workflow_id,
+        url=URL,
+        body=FIXTURE_A,
+        store=store,
+        catalog=catalog,
+    )
+    second = run_acquire_workflow(
+        system_database_url=dsn,
+        workflow_id="acquire-dc8-replay",
+        url=URL,
+        body=FIXTURE_A,
+        store=store,
+        catalog=catalog,
+    )
+    assert first.source_version_id == second.source_version_id
+    assert catalog.count_source_versions() == 1
+    assert first.sha256 == hashlib.sha256(FIXTURE_A).hexdigest()

--- a/tests/test_watcher.py
+++ b/tests/test_watcher.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import hashlib
+
+from rkp.acquisition.watcher import check_listing
+
+
+URL = "https://rbi.org.in/fixtures/listing.html"
+BODY = b"<html>listing v1</html>"
+
+
+class OkFetcher:
+    def get(self, url: str) -> bytes:
+        assert url == URL
+        return BODY
+
+
+class FailFetcher:
+    def get(self, url: str) -> bytes:
+        raise OSError("simulated network failure")
+
+
+def test_failure_alerts_and_is_not_no_change() -> None:
+    result = check_listing(url=URL, fetcher=FailFetcher(), previous_sha256="abc")
+    assert result.outcome == "failure"
+    assert result.alert is True
+    assert result.sha256 is None
+
+
+def test_successful_unchanged_check_is_no_change() -> None:
+    digest = hashlib.sha256(BODY).hexdigest()
+    result = check_listing(url=URL, fetcher=OkFetcher(), previous_sha256=digest)
+    assert result.outcome == "no_change"
+    assert result.alert is False
+    assert result.sha256 == digest
+
+
+def test_first_successful_check_is_changed() -> None:
+    result = check_listing(url=URL, fetcher=OkFetcher(), previous_sha256=None)
+    assert result.outcome == "changed"
+    assert result.alert is False


### PR DESCRIPTION
## What

R0 product gate on a branch (do not merge here).

- Content-addressed evidence store
- `rkp.sources` / `rkp.source_versions` with official/legal status defaults
- Idempotent `acquire()` and a DBOS workflow that replays the same workflow id without a second version
- Tests: 7 passed locally against PostgreSQL 18.6 + pgvector 0.8.6 on 127.0.0.1:5433
- CI workflow with pgvector/pg18 service

## Host (already on srv1447173)

- `wk-main` uid 1999, no docker group
- `rkp-postgres` container, loopback 5433 only
- Secrets in `/etc/rkp/rkp-postgres.env` (not in git)
- Evidence dir `/var/lib/rkp/evidence`

## Not in this PR

- Directus 12 (#3) — licence key still a secret, not installed
- Watcher skeleton (#5)
- Merge to main

## Test plan

- [x] `pytest -q` with `RKP_TEST_DATABASE_URL` on 5433: 7 passed
- [ ] CI on this PR